### PR TITLE
Update attack.go

### DIFF
--- a/attack.go
+++ b/attack.go
@@ -140,7 +140,7 @@ func attack(opts *attackOpts) error {
 			concurrency,
 			opts.number,
 		)
-		results = attacker.AttackConcy(targets, opts.concurrency, opts.number)
+		results = attacker.AttackConcy(targets, concurrency, opts.number)
 	}
 
 	log.Printf("Done! Writing results to '%s'...", opts.outputf)


### PR DESCRIPTION
should be concurrency, no opts.concurrency.  not a bug. In lib/attack.go+179 have the same judge
